### PR TITLE
Return exit code from SHOW command

### DIFF
--- a/src/Console/Command/ShowCommand.php
+++ b/src/Console/Command/ShowCommand.php
@@ -25,6 +25,8 @@ class ShowCommand extends \Symfony\Component\Console\Command\Command
 	const NAME = 'show';
 	const OPTION_IGNORE_REQUIRED_VERSION = 'ignore-required-version';
 	const OPTION_EXACT_AS_TILDA = 'exact-as-tilda';
+	const EXIT_CODE_UP_TO_DATE = 0;
+	const EXIT_CODE_OUTDATED = 1;
 
 	/** @var ComposerAccessor */
 	private $composerAccessor;
@@ -73,10 +75,12 @@ class ShowCommand extends \Symfony\Component\Console\Command\Command
 			$input->getOption(self::OPTION_IGNORE_REQUIRED_VERSION),
 			$input->getOption(self::OPTION_EXACT_AS_TILDA)
 		);
+		$versionStatus = self::EXIT_CODE_UP_TO_DATE;
 		foreach ($packages as $package) {
 			$currentVersion = $package->getCurrentVersion()->getPrettyString();
 			if (!$package->isLatest()) {
 				$currentVersion = sprintf('<error>%s</error>', $currentVersion);
+				$versionStatus = self::EXIT_CODE_OUTDATED;
 			}
 
 			$table->addRow([
@@ -87,6 +91,8 @@ class ShowCommand extends \Symfony\Component\Console\Command\Command
 		}
 
 		$table->render();
+
+		return $versionStatus;
 	}
 
 	/**


### PR DESCRIPTION
This PR fixes https://github.com/nella/victor/issues/7

Executing the show command (e.g. `composer victor show`) will now also return exit code (0 on success - i.e. all packages are up-to-date, 1 otherwise - i.e. some packages are outdated). This helps using victor in CI scripts.

Output with exit code 1:
![image](https://user-images.githubusercontent.com/2445436/49154121-ea917a00-f317-11e8-9526-9a329f09690b.png)

Output with exit code 0 (no change):
![image](https://user-images.githubusercontent.com/2445436/49154155-0432c180-f318-11e8-8d50-9d11514ce93c.png)

Thank you!